### PR TITLE
Fix onboarding function name

### DIFF
--- a/NewBabyApp/ContentView.swift
+++ b/NewBabyApp/ContentView.swift
@@ -25,7 +25,7 @@ struct ContentView: View {
     var body: some View {
         TabView(selection: $selected) {
             NavigationStack(path: $navigationPath) {
-                MenuView(model: LocalRepository.menuPregnant, clientName: clientName, path: $navigationPath, heartTapAction: showOnbording)
+                MenuView(model: LocalRepository.menuPregnant, clientName: clientName, path: $navigationPath, heartTapAction: showOnboarding)
                     .navigationDestination(for: NavigationDestination.self) { destination in
                         switch destination {
                         case .stories(let model):
@@ -50,7 +50,7 @@ struct ContentView: View {
                 .tag(0)
             
             NavigationStack(path: $navigationPath) {
-                MenuView(model: LocalRepository.menuHospital, clientName: clientName, path: $navigationPath, heartTapAction: showOnbording)
+                MenuView(model: LocalRepository.menuHospital, clientName: clientName, path: $navigationPath, heartTapAction: showOnboarding)
                     .navigationDestination(for: NavigationDestination.self) { destination in
                         switch destination {
                         case .stories(let model):
@@ -77,7 +77,7 @@ struct ContentView: View {
                 .tag(1)
             
             NavigationStack(path: $navigationPath) {
-                MenuView(model: LocalRepository.menuHome, clientName: clientName, path: $navigationPath, heartTapAction: showOnbording)
+                MenuView(model: LocalRepository.menuHome, clientName: clientName, path: $navigationPath, heartTapAction: showOnboarding)
                     .navigationDestination(for: NavigationDestination.self) { destination in
                         switch destination {
                         case .stories(let model):
@@ -108,7 +108,7 @@ struct ContentView: View {
         .background(Color.black)
     }
     
-    func showOnbording() {
+    func showOnboarding() {
         self.firstLaunch.toggle()
     }
 }


### PR DESCRIPTION
## Summary
- rename `showOnbording` to `showOnboarding`
- update all callers

## Testing
- `swiftc -o BuildTest $(find NewBabyApp -name '*.swift')` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6852e55d7298832a9621b51e5d609722