### PR TITLE
Refactor search label logic

### DIFF
--- a/NewBabyApp/Search/SearchRepository.swift
+++ b/NewBabyApp/Search/SearchRepository.swift
@@ -88,4 +88,12 @@ final class SearchRepository {
         }
         return exactTitleMatches + partialTitleMatches + otherMatches
     }
+
+    func subtitle(for destination: NavigationDestination) -> String {
+        if case let .menu(menuModel) = destination {
+            return menuModel.menuItems.map { $0.searchableText }.joined(separator: " ")
+        } else {
+            return destination.searchableText
+        }
+    }
 }

--- a/NewBabyApp/Search/SearchView.swift
+++ b/NewBabyApp/Search/SearchView.swift
@@ -23,16 +23,9 @@ struct SearchView: View {
                         VStack(alignment: .leading) {
                             Text(item.destination.title)
                                 .font(.headline)
-                            if case .menu(let menuModel) = item.destination {
-                                // Zobraz pouze obsah podmenu bez titulku
-                                Text(menuModel.menuItems.map { $0.searchableText }.joined(separator: " "))
-                                    .font(.subheadline)
-                                    .lineLimit(2)
-                            } else {
-                                Text(item.destination.searchableText)
-                                    .font(.subheadline)
-                                    .lineLimit(2)
-                            }
+                            Text(repo.subtitle(for: item.destination))
+                                .font(.subheadline)
+                                .lineLimit(2)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- provide a helper `subtitle(for:)` in `SearchRepository`
- simplify `SearchView` by calling the repository helper for the label text

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6863f68c8830832a87c0421ea33c3c2a