### PR TITLE
Add icons for search results

### DIFF
--- a/NewBabyApp/Models/NavigationDestination.swift
+++ b/NewBabyApp/Models/NavigationDestination.swift
@@ -84,8 +84,12 @@ extension NavigationDestination {
             return "list.bullet"
         case .introText:
             return "text.justify"
-        case .stories:
-            return "photo.on.rectangle"
+        case .stories(let model):
+            if model.stories.contains(where: { $0.type == .video }) {
+                return "play.rectangle"
+            } else {
+                return "photo.on.rectangle"
+            }
         case .text:
             return "doc.text"
         }

--- a/NewBabyApp/Models/NavigationDestination.swift
+++ b/NewBabyApp/Models/NavigationDestination.swift
@@ -77,6 +77,21 @@ enum NavigationDestination: Hashable {
     }
 }
 
+extension NavigationDestination {
+    var iconName: String {
+        switch self {
+        case .menu:
+            return "list.bullet"
+        case .introText:
+            return "text.justify"
+        case .stories:
+            return "photo.on.rectangle"
+        case .text:
+            return "doc.text"
+        }
+    }
+}
+
 // MARK: - Search
 extension NavigationDestination {
     

--- a/NewBabyApp/Search/SearchResultRow.swift
+++ b/NewBabyApp/Search/SearchResultRow.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct SearchResultRow: View {
+    let item: NavigationSearchItem
+    let repo: SearchRepository
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: item.destination.iconName)
+                .frame(width: 20)
+            VStack(alignment: .leading) {
+                Text(item.destination.title)
+                    .font(.headline)
+                Text(repo.subtitle(for: item.destination))
+                    .font(.subheadline)
+                    .lineLimit(2)
+            }
+        }
+    }
+}
+
+#Preview {
+    SearchResultRow(
+        item: NavigationSearchItem(destination: .introText(IntroTextModel(title: "Ukázka", content: AttributedString("Text"))),
+        repo: SearchRepository()
+    )
+}

--- a/NewBabyApp/Search/SearchView.swift
+++ b/NewBabyApp/Search/SearchView.swift
@@ -17,18 +17,30 @@ struct SearchView: View {
 
     var body: some View {
         NavigationStack {
-            List {
-                ForEach(filteredResults) { item in
-                    NavigationLink(value: item.destination) {
-                        HStack(alignment: .top, spacing: 8) {
-                            Image(systemName: item.destination.iconName)
-                                .frame(width: 20)
-                            VStack(alignment: .leading) {
-                                Text(item.destination.title)
-                                    .font(.headline)
-                                Text(repo.subtitle(for: item.destination))
-                                    .font(.subheadline)
-                                    .lineLimit(2)
+            Group {
+                if searchText.isEmpty {
+                    VStack {
+                        Spacer()
+                        Label("Zadejte hledaný text", systemImage: "magnifyingglass")
+                            .foregroundColor(.secondary)
+                        Spacer()
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    List {
+                        ForEach(filteredResults) { item in
+                            NavigationLink(value: item.destination) {
+                                HStack(alignment: .top, spacing: 8) {
+                                    Image(systemName: item.destination.iconName)
+                                        .frame(width: 20)
+                                    VStack(alignment: .leading) {
+                                        Text(item.destination.title)
+                                            .font(.headline)
+                                        Text(repo.subtitle(for: item.destination))
+                                            .font(.subheadline)
+                                            .lineLimit(2)
+                                    }
+                                }
                             }
                         }
                     }

--- a/NewBabyApp/Search/SearchView.swift
+++ b/NewBabyApp/Search/SearchView.swift
@@ -20,12 +20,16 @@ struct SearchView: View {
             List {
                 ForEach(filteredResults) { item in
                     NavigationLink(value: item.destination) {
-                        VStack(alignment: .leading) {
-                            Text(item.destination.title)
-                                .font(.headline)
-                            Text(repo.subtitle(for: item.destination))
-                                .font(.subheadline)
-                                .lineLimit(2)
+                        HStack(alignment: .top, spacing: 8) {
+                            Image(systemName: item.destination.iconName)
+                                .frame(width: 20)
+                            VStack(alignment: .leading) {
+                                Text(item.destination.title)
+                                    .font(.headline)
+                                Text(repo.subtitle(for: item.destination))
+                                    .font(.subheadline)
+                                    .lineLimit(2)
+                            }
                         }
                     }
                 }

--- a/NewBabyApp/Search/SearchView.swift
+++ b/NewBabyApp/Search/SearchView.swift
@@ -30,17 +30,7 @@ struct SearchView: View {
                     List {
                         ForEach(filteredResults) { item in
                             NavigationLink(value: item.destination) {
-                                HStack(alignment: .top, spacing: 8) {
-                                    Image(systemName: item.destination.iconName)
-                                        .frame(width: 20)
-                                    VStack(alignment: .leading) {
-                                        Text(item.destination.title)
-                                            .font(.headline)
-                                        Text(repo.subtitle(for: item.destination))
-                                            .font(.subheadline)
-                                            .lineLimit(2)
-                                    }
-                                }
+                                SearchResultRow(item: item, repo: repo)
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- enhance search results with icons for the destination type
- provide `iconName` helper on `NavigationDestination`

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6863f86d9e08832a97defc70bf78c875