### PR TITLE
Fix Stories top margin from search

### DIFF
--- a/NewBabyApp/DetailViews/StoriesView.swift
+++ b/NewBabyApp/DetailViews/StoriesView.swift
@@ -28,10 +28,11 @@ struct StoriesView: View {
     } }
     
     var body: some View {
-        if storiesGroup.stories.isEmpty {
-            Text("Tady není nic k vidění") // TODO: dodělat vtipný emptyview
-        } else {
-            ZStack (alignment: .topTrailing) {
+        Group {
+            if storiesGroup.stories.isEmpty {
+                Text("Tady není nic k vidění") // TODO: dodělat vtipný emptyview
+            } else {
+                ZStack (alignment: .topTrailing) {
                 if let story = storiesGroup.stories[safe: selectedStory] {
                     GeometryReader { proxy in
                         VStack(spacing: 8) {
@@ -90,8 +91,9 @@ struct StoriesView: View {
                 }
                 #endif
             }
-            
+
         }
+        .navigationBarHidden(true)
     }
     
     func resetProgress() {


### PR DESCRIPTION
## Summary
- avoid showing the navigation bar in `StoriesView`
- group root view in `StoriesView` to apply the navigation bar modifier

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68640e5742a8832ab1d15804b776f25f