### PR TITLE
Update AudioManager for persistent background playback

### DIFF
--- a/NewBabyApp.xcodeproj/project.pbxproj
+++ b/NewBabyApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		CF4173EF2E150E7B00D6F11E /* MenuBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4173EE2E150E7800D6F11E /* MenuBackground.swift */; };
 		CF4173F12E15148300D6F11E /* WaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4173F02E15148300D6F11E /* WaveformView.swift */; };
 		CF4173F32E15194E00D6F11E /* bonding.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = CF4173F22E15194E00D6F11E /* bonding.mp3 */; };
+		CF4173FB2E153C1E00D6F11E /* AudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4173FA2E153C1E00D6F11E /* AudioManager.swift */; };
 		CF478D0B2DEF89E2003AE7D8 /* HomeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF478C672DEF89E2003AE7D8 /* HomeRepository.swift */; };
 		CF478D0C2DEF89E2003AE7D8 /* HospitalRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF478C682DEF89E2003AE7D8 /* HospitalRepository.swift */; };
 		CF478D0D2DEF89E2003AE7D8 /* LocalRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF478C692DEF89E2003AE7D8 /* LocalRepository.swift */; };
@@ -211,6 +212,8 @@
 		CF4173EE2E150E7800D6F11E /* MenuBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBackground.swift; sourceTree = "<group>"; };
 		CF4173F02E15148300D6F11E /* WaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformView.swift; sourceTree = "<group>"; };
 		CF4173F22E15194E00D6F11E /* bonding.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = bonding.mp3; sourceTree = "<group>"; };
+		CF4173FA2E153C1E00D6F11E /* AudioManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioManager.swift; sourceTree = "<group>"; };
+		CF4173FC2E153CA700D6F11E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		CF478C672DEF89E2003AE7D8 /* HomeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRepository.swift; sourceTree = "<group>"; };
 		CF478C682DEF89E2003AE7D8 /* HospitalRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HospitalRepository.swift; sourceTree = "<group>"; };
 		CF478C692DEF89E2003AE7D8 /* LocalRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalRepository.swift; sourceTree = "<group>"; };
@@ -692,6 +695,8 @@
 		CF478D0A2DEF89E2003AE7D8 /* NewBabyApp */ = {
 			isa = PBXGroup;
 			children = (
+				CF4173FC2E153CA700D6F11E /* Info.plist */,
+				CF4173FA2E153C1E00D6F11E /* AudioManager.swift */,
 				CF4173E52E150D6500D6F11E /* MenuItems */,
 				CFF992CB2DFF164E00859DC9 /* Search */,
 				CF71A5A62DFC10A0003AEDC0 /* Extension */,
@@ -989,6 +994,7 @@
 				CF4173E92E150E1700D6F11E /* DoubleMenuItemView.swift in Sources */,
 				CF4173EB2E150E3800D6F11E /* MenuItemView.swift in Sources */,
 				CF4173E02E1502B600D6F11E /* PodcastView.swift in Sources */,
+				CF4173FB2E153C1E00D6F11E /* AudioManager.swift in Sources */,
 				CF478D132DEF89E2003AE7D8 /* VideoPlayerViewModel.swift in Sources */,
 				CF478D142DEF89E2003AE7D8 /* VideoPlayerView.swift in Sources */,
 				CF478D172DEF89E2003AE7D8 /* IntroTextModel.swift in Sources */,
@@ -1157,6 +1163,7 @@
 				DEVELOPMENT_TEAM = BY8G7HDNPV;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = NewBabyApp/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.medical";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1191,6 +1198,7 @@
 				DEVELOPMENT_TEAM = BY8G7HDNPV;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = NewBabyApp/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.medical";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/NewBabyApp.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/NewBabyApp.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/NewBabyApp.xcodeproj/project.xcworkspace/xcuserdata/daliborjanecek.xcuserdatad/WorkspaceSettings.xcsettings
+++ b/NewBabyApp.xcodeproj/project.xcworkspace/xcuserdata/daliborjanecek.xcuserdatad/WorkspaceSettings.xcsettings
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildLocationStyle</key>
+	<string>UseAppPreferences</string>
+	<key>CustomBuildLocationType</key>
+	<string>RelativeToDerivedData</string>
+	<key>DerivedDataLocationStyle</key>
+	<string>Default</string>
+	<key>ShowSharedSchemesAutomaticallyEnabled</key>
+	<true/>
+</dict>
+</plist>

--- a/NewBabyApp/AudioManager.swift
+++ b/NewBabyApp/AudioManager.swift
@@ -1,0 +1,144 @@
+import AVFoundation
+import MediaPlayer
+import Combine
+import UIKit
+
+class AudioManager: NSObject, ObservableObject, AVAudioPlayerDelegate {
+    static let shared = AudioManager()
+
+    @Published var isPlaying: Bool = false
+    @Published var progress: Double = 0
+    @Published var currentTitle: String = ""
+    @Published var currentFile: String? = nil
+
+    var currentTime: TimeInterval { player?.currentTime ?? 0 }
+    var duration: TimeInterval { player?.duration ?? 0 }
+
+    private var player: AVAudioPlayer?
+    private var timer: Timer?
+
+    private override init() {
+        super.init()
+        configureAudioSession()
+        setupRemoteTransportControls()
+        observeLifecycle()
+    }
+
+    func togglePlay(fileName: String, title: String) {
+        if currentFile != fileName {
+            load(fileName: fileName, title: title)
+        }
+        guard let player else { return }
+        if player.isPlaying {
+            pause()
+        } else {
+            play()
+        }
+    }
+
+    func play() {
+        guard let player else { return }
+        player.play()
+        isPlaying = true
+        startTimer()
+        updateNowPlaying(playbackRate: 1)
+    }
+
+    func pause() {
+        guard let player else { return }
+        player.pause()
+        isPlaying = false
+        stopTimer()
+        updateNowPlaying(playbackRate: 0)
+    }
+
+    func seek(to progress: Double) {
+        guard let player else { return }
+        let clamped = max(0, min(progress, 1))
+        player.currentTime = clamped * player.duration
+        self.progress = clamped
+        updateNowPlaying(playbackRate: player.isPlaying ? 1 : 0)
+    }
+
+    // MARK: - Private
+
+    private func load(fileName: String, title: String) {
+        if let url = Bundle.main.url(forResource: fileName, withExtension: "mp3") {
+            player = try? AVAudioPlayer(contentsOf: url)
+            player?.delegate = self
+            player?.prepareToPlay()
+            currentFile = fileName
+            currentTitle = title
+            progress = 0
+        }
+    }
+
+    private func configureAudioSession() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playback, mode: .spokenAudio, options: [.allowAirPlay, .allowBluetooth])
+            try session.setActive(true)
+            UIApplication.shared.beginReceivingRemoteControlEvents()
+        } catch {
+            print("Audio session setup failed: \(error)")
+        }
+    }
+
+    private func setupRemoteTransportControls() {
+        let commandCenter = MPRemoteCommandCenter.shared()
+        commandCenter.playCommand.addTarget { [weak self] _ in
+            self?.play(); return .success
+        }
+        commandCenter.pauseCommand.addTarget { [weak self] _ in
+            self?.pause(); return .success
+        }
+    }
+
+    private func observeLifecycle() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(activateSession),
+                                               name: UIApplication.didEnterBackgroundNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(activateSession),
+                                               name: UIApplication.willEnterForegroundNotification,
+                                               object: nil)
+    }
+
+    @objc private func activateSession() {
+        try? AVAudioSession.sharedInstance().setActive(true)
+    }
+
+    private func startTimer() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+            guard let self, let player = self.player else { return }
+            self.progress = player.duration > 0 ? player.currentTime / player.duration : 0
+            self.updateNowPlaying(playbackRate: player.isPlaying ? 1 : 0)
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func updateNowPlaying(playbackRate: Float = 0) {
+        guard let player else { return }
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = [
+            MPMediaItemPropertyTitle: currentTitle,
+            MPNowPlayingInfoPropertyElapsedPlaybackTime: player.currentTime,
+            MPMediaItemPropertyPlaybackDuration: player.duration,
+            MPNowPlayingInfoPropertyPlaybackRate: playbackRate
+        ]
+    }
+
+    // MARK: - AVAudioPlayerDelegate
+
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        isPlaying = false
+        progress = 0
+        stopTimer()
+        updateNowPlaying(playbackRate: 0)
+    }
+}

--- a/NewBabyApp/Info.plist
+++ b/NewBabyApp/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- keep audio session active when the app moves to the background
- start receiving remote control events
- observe lifecycle notifications so playback isn't paused by the OS

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6864ec20a474832aa30ae35d495f8ea1